### PR TITLE
Launch a bunch of images by GUID

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -19,10 +19,10 @@ def after_feature(context, feature):
 
 
 def before_scenario(context, scenario):
-    # benv.before_scenario(context, scenario)
-    pass
+    if 'persist_browser' not in scenario.tags:
+        benv.before_scenario(context, scenario)
 
 
 def after_scenario(context, scenario):
-    # benv.after_scenario(context, scenario)
-    pass
+    if 'persist_browser' not in scenario.tags:
+        benv.after_scenario(context, scenario)

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,10 +1,16 @@
 import os
 
+try:
+    from urlparse import urlparse, urlunsplit
+except ImportError:
+    from urllib.parse import urlparse, urlunsplit
+
 from behaving import environment as benv
 
 def before_all(context):
     benv.before_all(context)
     context.default_browser = os.environ.get('SANITYBROWSER', '')
+    context.base_url = get_base_url(os.environ['SANITYURL'])
 
 def after_all(context):
     benv.after_all(context)
@@ -26,3 +32,12 @@ def before_scenario(context, scenario):
 def after_scenario(context, scenario):
     if 'persist_browser' not in scenario.tags:
         benv.after_scenario(context, scenario)
+
+
+def get_base_url(url):
+    """
+    Get base URL from a URL (i.e. just the scheme & hostname)
+    """
+    url_parts = urlparse(url)
+    base_url = urlunsplit((url_parts.scheme, url_parts.hostname, '', '', ''))
+    return base_url

--- a/features/environment.py
+++ b/features/environment.py
@@ -2,11 +2,9 @@ import os
 
 from behaving import environment as benv
 
-
 def before_all(context):
     benv.before_all(context)
     context.default_browser = os.environ.get('SANITYBROWSER', '')
-
 
 def after_all(context):
     benv.after_all(context)
@@ -21,8 +19,10 @@ def after_feature(context, feature):
 
 
 def before_scenario(context, scenario):
-    benv.before_scenario(context, scenario)
+    # benv.before_scenario(context, scenario)
+    pass
 
 
 def after_scenario(context, scenario):
-    benv.after_scenario(context, scenario)
+    # benv.after_scenario(context, scenario)
+    pass

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -33,15 +33,21 @@ Feature: Launch all featured images
         Then I should see "Build" within 60 seconds
 
     Examples: Selected images
-        | image-guid                           | image-name                    | provider                       |
-        | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1     | iPlant Cloud - Tucson​ |
-        | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base      | iPlant Cloud - Tucson​ |
-        | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base   | iPlant Cloud - Tucson​ |
+      | image-guid                           | image-name                     | provider                        |
+      | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1      | iPlant Cloud - Tucson​           |
+      | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base       | iPlant Cloud - Tucson​           |
+      | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base    | iPlant Cloud - Tucson​           |
+      | 5de53056-9448-4519-b9b7-74dde60b9905 | Ubuntu 14.04 with Docker 1.7.x | iPlant Cloud - Tucson​           |
+      | 7a7f187f-a5dc-4c23-8197-ed3f114a1a2c | functional genomics_v1.0       | iPlant Cloud - Tucson​           |
 
-        | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1     | iPlant Cloud - Austin​ |
-        | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base      | iPlant Cloud - Austin​ |
-        | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base   | iPlant Cloud - Austin​ |
+      | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1      | iPlant Cloud - Austin​           |
+      | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base       | iPlant Cloud - Austin​           |
+      | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base    | iPlant Cloud - Austin​           |
+      | 5de53056-9448-4519-b9b7-74dde60b9905 | Ubuntu 14.04 with Docker 1.7.x | iPlant Cloud - Austin​           |
+      | 7a7f187f-a5dc-4c23-8197-ed3f114a1a2c | functional genomics_v1.0       | iPlant Cloud - Austin           |
 
-        | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1     | iPlant Workshop Cloud - Tucson​ |
-        | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base      | iPlant Workshop Cloud - Tucson​ |
-        | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base   | iPlant Workshop Cloud - Tucson​ |
+      | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1      | iPlant Workshop Cloud - Tucson​  |
+      | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base       | iPlant Workshop Cloud - Tucson​  |
+      | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base    | iPlant Workshop Cloud - Tucson​  |
+      | 5de53056-9448-4519-b9b7-74dde60b9905 | Ubuntu 14.04 with Docker 1.7.x | iPlant Workshop Cloud - Tucson​​  |
+      | 7a7f187f-a5dc-4c23-8197-ed3f114a1a2c | functional genomics_v1.0       | iPlant Workshop Cloud - Tucson​  |

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -1,0 +1,44 @@
+# This feature launches all of the featured images on all of the providers of Atmosphere and ensures they get to the networking step
+
+Feature: Launch all featured images
+
+    Scenario: Log into atmosphere
+        Given a browser
+        When I login to Atmosphere
+
+    Scenario: Create project
+        Given a browser
+        Then I create project "BDD-01" if necessary
+
+    Scenario Outline: Launch all featured images
+        Given a browser
+        # Launch instance
+        Then I should see and press "Images" within 10 seconds
+        Then I should see "SEARCH" within 10 seconds
+        When I type slowly "<image-guid>" to "0" index of class "form-control"
+        Then I should see "<image-name>" within 15 seconds
+        Then I press "<image-name>"
+        Then I should see and press "Launch" within 10 seconds
+        Then I should see "Launch an Instance / Basic Options" within 10 seconds
+        And I should see "alloted GBs of Memory" within 10 seconds
+        And I choose provider "<provider>" from Provider dropdown
+        When I choose "BDD-01" from Project dropdown
+        # This button sometimes gives trouble
+        And I press "Launch Instance"
+        And I wait for 3 seconds
+        And I double-check that I press "Launch Instance"
+        Then I should see "Build" within 60 seconds
+
+    Examples: Selected images
+        | image-guid                           | image-name                    | provider                       |
+        | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1     | iPlant Cloud - Tucson​ |
+        | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base      | iPlant Cloud - Tucson​ |
+        | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base   | iPlant Cloud - Tucson​ |
+
+        | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1     | iPlant Cloud - Austin​ |
+        | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base      | iPlant Cloud - Austin​ |
+        | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base   | iPlant Cloud - Austin​ |
+
+        | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1     | iPlant Workshop Cloud - Tucson​ |
+        | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base      | iPlant Workshop Cloud - Tucson​ |
+        | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base   | iPlant Workshop Cloud - Tucson​ |

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -19,13 +19,13 @@ Feature: Launch all featured images
         Then I should see and press "Images" within 10 seconds
         Then I should see "SEARCH" within 10 seconds
         When I type slowly "<image-guid>" to "0" index of class "form-control"
-        Then I should see "<image-name>" within 15 seconds
-        Then I press "<image-name>"
+        Then I should see "<image-name>" within 20 seconds
+        When I press "<image-name>"
         Then I should see and press "Launch" within 10 seconds
-        Then I should see "Launch an Instance / Basic Options" within 10 seconds
+        And I should see "Launch an Instance / Basic Options" within 10 seconds
         And I should see "alloted GBs of Memory" within 10 seconds
-        And I choose provider "<provider>" from Provider dropdown
-        When I choose "BDD-01" from Project dropdown
+        When I choose provider "<provider>" from Provider dropdown
+        And I choose "BDD-01" from Project dropdown
         # This button sometimes gives trouble
         And I press "Launch Instance"
         And I wait for 3 seconds

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -2,14 +2,17 @@
 
 Feature: Launch all featured images
 
+    @persist_browser
     Scenario: Log into atmosphere
         Given a browser
         When I login to Atmosphere
 
+    @persist_browser
     Scenario: Create project
         Given a browser
         Then I create project "BDD-01" if necessary
 
+    @persist_browser
     Scenario Outline: Launch all featured images
         Given a browser
         # Launch instance

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -1,6 +1,4 @@
-# This feature launches all of the featured images on all of the providers of Atmosphere and ensures they get to the networking step
-
-Feature: Launch all featured images
+Feature: Launch a set of images defined by name and GUID
 
     @persist_browser
     Scenario: Log into atmosphere

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -16,7 +16,7 @@ Feature: Launch all featured images
     Scenario Outline: Launch all featured images
         Given a browser
         # Launch instance
-        Then I should see and press "Images" within 10 seconds
+        When I go to "/application/images"
         Then I should see "SEARCH" within 10 seconds
         When I type slowly "<image-guid>" to "0" index of class "form-control"
         Then I should see "<image-name>" within 20 seconds

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -94,21 +94,20 @@ def i_login_to_atmo(context):
     # visit URL
     context.browser.visit(os.environ['SANITYURL'])
     # Only press login if we're not using a backdoor
-    if os.environ['SANITYURL'].endswith(APPLICATION_BACKDOOR):
-        return
-    # press login
-    assert context.browser.is_text_present('Login', wait_time=10), u'Text not found'
-    name = 'Login'
-    element = context.browser.find_by_xpath(
-        ("//*[@id='%(name)s']|"
-         "//*[@name='%(name)s']|"
-         "//button[contains(string(), '%(name)s')]|"
-         "//input[@type='button' and contains(string(), '%(name)s')]|"
-         "//input[@type='button' and contains(@value, '%(name)s')]|"
-         "//input[@type='submit' and contains(@value, '%(name)s')]|"
-         "//a[contains(string(), '%(name)s')]") % {'name': name})
-    assert element, u'Element not found'
-    element.first.click()
+    if not os.environ['SANITYURL'].endswith(APPLICATION_BACKDOOR):
+        # Press Login in Troposphere UI
+        assert context.browser.is_text_present('Login', wait_time=10), u'Text not found'
+        name = 'Login'
+        element = context.browser.find_by_xpath(
+            ("//*[@id='%(name)s']|"
+             "//*[@name='%(name)s']|"
+             "//button[contains(string(), '%(name)s')]|"
+             "//input[@type='button' and contains(string(), '%(name)s')]|"
+             "//input[@type='button' and contains(@value, '%(name)s')]|"
+             "//input[@type='submit' and contains(@value, '%(name)s')]|"
+             "//a[contains(string(), '%(name)s')]") % {'name': name})
+        assert element, u'Element not found'
+        element.first.click()
     # enter info
     context.browser.fill("username", os.environ.get('SANITYUSER'))
     context.browser.fill("password", os.environ.get('SANITYPASS'))
@@ -146,7 +145,7 @@ def i_choose_in_provider_dropdown(context, provider):
     # sometimes a non-printing space unicode character gets appended
     if not provider[-1].isalpha():
         provider = provider[:-1]
-    select.select_by_visible_text(provider)    
+    select.select_by_visible_text(provider)
 
 @step(u'I enter the Web Shell')
 def i_enter_web_shell(context):
@@ -206,7 +205,7 @@ def i_create_project(context, project):
             u'Element not found or could not set name'
         for key in context.browser.type(name, project, slowly=True):
             assert key
-        
+
         # And I type slowly "%s" to "1" index of class "form-control"
         name = "temp_form_name_1"
         assert context.browser.evaluate_script("document.getElementsByClassName('form-control')[1].name = '%s'" % (name)), \

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -65,15 +65,15 @@ def i_press_delete(context):
 @step(u'I should see and press "{name}" within {timeout:d} seconds')
 def i_should_see_and_press_within_timeout(context, name, timeout):
     assert context.browser.is_text_present(name, wait_time=timeout), u'Text not found'
-    element = context.browser.find_by_xpath(
-        ("//*[@id='%(name)s']|"
-         "//*[@name='%(name)s']|"
-         "//button[contains(string(), '%(name)s')]|"
-         "//input[@type='button' and contains(string(), '%(name)s')]|"
-         "//input[@type='button' and contains(@value, '%(name)s')]|"
-         "//input[@type='submit' and contains(@value, '%(name)s')]|"
-         "//a[contains(string(), '%(name)s')]") % {'name': name})
-    assert element, u'Element not found'
+    element_xpath = "//*[@id='%(name)s']|" \
+                    "//*[@name='%(name)s']|" \
+                    "//button[contains(string(), '%(name)s')]|" \
+                    "//input[@type='button' and contains(string(), '%(name)s')]|" \
+                    "//input[@type='button' and contains(@value, '%(name)s')]|" \
+                    "//input[@type='submit' and contains(@value, '%(name)s')]|" \
+                    "//a[contains(string(), '%(name)s')]" % {'name': name}
+    assert context.browser.is_element_visible_by_xpath(element_xpath, wait_time=10)
+    element = context.browser.find_by_xpath(element_xpath)
     element.first.click()
 
 @step(u'I double-check that I press "{name}"')
@@ -143,7 +143,7 @@ def i_choose_in_provider_dropdown(context, provider):
     assert elem, u'Element not found'
     select = Select(elem)
     # sometimes a non-printing space unicode character gets appended
-    if not provider[-1].isalpha():
+    while not provider[-1].isalpha():
         provider = provider[:-1]
     select.select_by_visible_text(provider)
 
@@ -200,10 +200,11 @@ def i_create_project(context, project):
         assert context.browser.is_text_present(name, wait_time=10), u'Text not found'
 
         # And I type slowly "%s" to "0" index of class "form-control"
-        name = "temp_form_name_0"
-        assert context.browser.evaluate_script("document.getElementsByClassName('form-control')[0].name = '%s'" % (name)), \
-            u'Element not found or could not set name'
-        for key in context.browser.type(name, project, slowly=True):
+        assert context.browser.is_element_visible_by_xpath("//div[@class='modal-body']//input[@type='text']",
+                                                           wait_time=10)
+        element = context.browser.find_by_xpath("//div[@class='modal-body']//input[@type='text']")
+        assert element, u'Element not found'
+        for key in element.first.type(project, slowly=True):
             assert key
 
         # And I type slowly "%s" to "1" index of class "form-control"

--- a/readme.md
+++ b/readme.md
@@ -44,8 +44,7 @@ Before you run the test suite, you also need to populate an environment variable
 
 Please do not store your Atmosphere password persistently in plaintext.
 
-You can also set a browser to use. The default browser is Firefox. To use Chrome, set the SANITYBROWSER environment
-variable:
+You can also set a browser to use. The default browser is Firefox. To use Chrome, set the SANITYBROWSER environment variable:
 
 `export SANITYBROWSER=chrome`
 
@@ -95,6 +94,8 @@ where 38 is the line number.
 
 **Q.** Why not use personas?  
 **A.** Behave-parallel doesn't have `context.execute_steps` implemented, which personas make heavy use of. This is also why some steps in steps.py are enormous.
+
+Some of the scenarios use the `@persist_browser` tag, which does not destroy browser state between scenarios (as configured in `environment.py`).
 
 ## To do:
 - test ssh functionality in test.feature using paramiko

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Before you run the test suite, you also need to populate an environment variable
 
 Please do not store your Atmosphere password persistently in plaintext.
 
-You can also set a browser to use. The default browser is Firefox. To use Chrome, set the SANITYBROWSER environment 
+You can also set a browser to use. The default browser is Firefox. To use Chrome, set the SANITYBROWSER environment
 variable:
 
 `export SANITYBROWSER=chrome`
@@ -58,6 +58,9 @@ where 2 is the max number of processes you want run.
 Alternatively, the script can be used as a guidebook for running each step of the test suite individually. Open run.bash in a text editor and manually copy each step into the command line. You'll have to manually change the `$PROCESSES` variable to the number of processes you want to run, usually 2-4.
 
 ### Reference:
+To launch a bunch of instances specified by GUID and name:
+`behave features/launch-by-guid.feature`
+
 To run a single feature:  
 `behave features/launch.feature`
 


### PR DESCRIPTION
We can now launch an arbitrary list of images by specifying their GUID/name: the test suite searches for these images and launches them. I have made this fast by:
- Not waiting for instance to enter networking status; only build status
- Not destroying browser state between scenarios, using the `@persist_browser` tag

It also runs in series rather than parallel, to avoid issues that were observed with multiple concurrent browser sessions to Atmosphere(1).
