### PR TITLE
Problem: Annoying things: Moving instances to projects, and having to…

### DIFF
--- a/features/jetstream-launch-by-guid.feature
+++ b/features/jetstream-launch-by-guid.feature
@@ -17,40 +17,42 @@ Feature: Launch all featured images
   @persist_browser
   Scenario Outline: Launch all featured images
     Given a browser
-      # Launch instance
+    When I go to "/application/projects"
+    Then I should see an element with xpath "//h2[contains(string(), 'BDD-01')]" within 10 seconds
+    When I press the element with xpath "//h2[contains(string(), 'BDD-01')]"
+    Then I should see an element with xpath "//h1[contains(string(), 'BDD-01')]" within 10 seconds
+    And I should skip this scenario if I see an instance with "<image-name>" and provider "<provider>"
     When I go to "/application/images"
     And I migrate resources to project "BDD-01" if necessary
-    Then I should see "SEARCH" within 20 seconds
+    Then I should see "SEARCH" within 60 seconds
     And I should see an element with the css selector ".form-control" within 10 seconds
     When I type slowly "<image-guid>" to "0" index of class "form-control"
-    Then I should see "<image-name>" within 20 seconds
+    Then I should see "<image-name>" within 60 seconds
     When I press the element with xpath "//h2[contains(string(), '<image-name>')]"
     Then I should see an element with the css selector ".launch-button" within 10 seconds
     And element with xpath "//button[contains(@class, 'launch-button')]" should be enabled within 5 seconds
     When I press the element with xpath "//button[contains(@class, 'launch-button')]"
-    And I should see "Launch an Instance / Basic Options" within 10 seconds
+    And I should see "Launch an Instance / Basic Options" within 60 seconds
     And I should see "alloted GBs of Memory" within 10 seconds
     When I choose option "<provider>" from dropdown with label "Provider"
     And I choose option "<size>" from dropdown with label "Instance Size"
     And I choose option "BDD-01" from dropdown with label "Project"
       # This button sometimes gives trouble
     And I press "Launch Instance"
-    And I wait for 3 seconds
+    And I wait for 10 seconds
     And I double-check that I press "Launch Instance"
-    And I wait for 2 seconds
-    Then I should see "Build" within 60 seconds
-
+    And I wait up to 90 seconds for instance with name "<image-name>" and provider "<provider>" to finish building
     Examples: Selected images
       | image-guid                           | image-name                     | provider                       | size      |
       | 30f31162-2a7a-4ac5-be1a-45c7e579a04b | Ubuntu 14.04.3 Development GUI | Jetstream - Indiana University | m1.small  |
       | 30f31162-2a7a-4ac5-be1a-45c7e579a04b | Ubuntu 14.04.3 Development GUI | Jetstream - TACC               | m1.small  |
-      | 4c25454d-8716-4cd5-841d-d00981536170 | Centos 7 (7.2) Development GUI | Jetstream - Indiana University | m1.small  |
-      | 4c25454d-8716-4cd5-841d-d00981536170 | Centos 7 (7.2) Development GUI | Jetstream - TACC               | m1.small  |
+      | 4c25454d-8716-4cd5-841d-d00981536170 | Centos 7 (7.3) Development GUI | Jetstream - Indiana University | m1.small  |
+      | 4c25454d-8716-4cd5-841d-d00981536170 | Centos 7 (7.3) Development GUI | Jetstream - TACC               | m1.small  |
       | 66322719-5bfa-4646-93c6-0132e9a958e5 | R with Intel compilers         | Jetstream - Indiana University | m1.small  |
       | 66322719-5bfa-4646-93c6-0132e9a958e5 | R with Intel compilers         | Jetstream - TACC               | m1.small  |
       | 798830e0-9053-4700-a3bd-4acda9935cc2 | CentOS 6 (6.8) Development GUI | Jetstream - Indiana University | m1.small  |
       | 798830e0-9053-4700-a3bd-4acda9935cc2 | CentOS 6 (6.8) Development GUI | Jetstream - TACC               | m1.small  |
       | 906e09cf-2827-49c5-82fd-ea74aa527e1d | BioLinux 8                     | Jetstream - Indiana University | m1.small  |
       | 906e09cf-2827-49c5-82fd-ea74aa527e1d | BioLinux 8                     | Jetstream - TACC               | m1.small  |
-      | f9dd55f2-c25b-4dcb-b95e-40d194965c78 | MATLAB (CentOS 6)              | Jetstream - Indiana University | m1.medium |
-      | f9dd55f2-c25b-4dcb-b95e-40d194965c78 | MATLAB (CentOS 6)              | Jetstream - TACC               | m1.medium |
+      | 73c161ae-2ad9-4379-87c4-0f05692be60b | MATLAB (Based on CentOS 6)     | Jetstream - Indiana University | m1.medium |
+      | 73c161ae-2ad9-4379-87c4-0f05692be60b | MATLAB (Based on CentOS 6)     | Jetstream - TACC               | m1.medium |

--- a/features/launch-by-guid.feature
+++ b/features/launch-by-guid.feature
@@ -16,10 +16,14 @@ Feature: Launch all featured images
   @persist_browser
   Scenario Outline: Launch all featured images
     Given a browser
-      # Launch instance
+    When I go to "/application/projects"
+    Then I should see an element with xpath "//h2[contains(string(), 'BDD-01')]" within 10 seconds
+    When I press the element with xpath "//h2[contains(string(), 'BDD-01')]"
+    Then I should see an element with xpath "//h1[contains(string(), 'BDD-01')]" within 10 seconds
+    And I should skip this scenario if I see an instance with "<image-name>" and provider "<provider>"
     When I go to "/application/images"
     And I migrate resources to project "BDD-01" if necessary
-    Then I should see "SEARCH" within 20 seconds
+    Then I should see "SEARCH" within 60 seconds
     And I should see an element with the css selector ".form-control" within 10 seconds
     When I type slowly "<image-guid>" to "0" index of class "form-control"
     Then I should see "<image-name>" within 60 seconds
@@ -27,18 +31,16 @@ Feature: Launch all featured images
     Then I should see an element with the css selector ".launch-button" within 10 seconds
     And element with xpath "//button[contains(@class, 'launch-button')]" should be enabled within 5 seconds
     When I press the element with xpath "//button[contains(@class, 'launch-button')]"
-    And I should see "Launch an Instance / Basic Options" within 10 seconds
+    And I should see "Launch an Instance / Basic Options" within 60 seconds
     And I should see "alloted GBs of Memory" within 10 seconds
     When I choose option "<provider>" from dropdown with label "Provider"
     And I choose option "<size>" from dropdown with label "Instance Size"
     And I choose option "BDD-01" from dropdown with label "Project"
       # This button sometimes gives trouble
     And I press "Launch Instance"
-    And I wait for 3 seconds
+    And I wait for 10 seconds
     And I double-check that I press "Launch Instance"
-    And I wait for 2 seconds
-    Then I should see "Build" within 60 seconds
-
+    And I wait up to 90 seconds for instance with name "<image-name>" and provider "<provider>" to finish building
     Examples: Selected images
       | image-guid                           | image-name                     | provider                       | size                                      |
       | c3ff7e02-98d1-43c9-b84f-9f7cd79bec4d | Ubuntu 12.04 Unity GUI v1      | iPlant Cloud - Tucson          | tiny1 (CPU: 1, Mem: 4 GB, Disk: 30 GB)    |
@@ -47,8 +49,8 @@ Feature: Launch all featured images
       | 5de53056-9448-4519-b9b7-74dde60b9905 | Ubuntu 14.04 with Docker 1.7.x | iPlant Cloud - Tucson          | tiny1 (CPU: 1, Mem: 4 GB, Disk: 30 GB)    |
       | 7a7f187f-a5dc-4c23-8197-ed3f114a1a2c | functional genomics_v1.0       | iPlant Cloud - Tucson          | tiny1 (CPU: 1, Mem: 4 GB, Disk: 30 GB)    |
       | 538537d7-b243-463c-b156-86b9e965bb88 | Software Carpentry 06-07-2016  | iPlant Cloud - Tucson          | tiny1 (CPU: 1, Mem: 4 GB, Disk: 30 GB)    |
-      # Note "Ubuntu 12.04 Unity GUI v1" does not exist on Austin
 
+      # Note "Ubuntu 12.04 Unity GUI v1" does not exist on Austin
 #      | d559c236-53ef-437a-999e-02ae16c4b5f0 | Ubuntu 14.04.2 XFCE Base       | iPlant Cloud - Austin          | tiny (CPU: 1, Mem: 4 GB)                  |
 #      | 524bd34b-5579-4f7e-958b-172ff6c403db | CyVerse CentOS 6.8 GUI Base    | iPlant Cloud - Austin          | tiny (CPU: 1, Mem: 4 GB)                  |
 #      | 5de53056-9448-4519-b9b7-74dde60b9905 | Ubuntu 14.04 with Docker 1.7.x | iPlant Cloud - Austin          | tiny (CPU: 1, Mem: 4 GB)                  |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,12 +1,7 @@
-from behave import *
-from behaving.web.steps import *
-from behaving.sms.steps import *
 from behaving.mail.steps import *
-from behaving.notifications.gcm.steps import *
-from behaving.personas.steps import *
 from behaving.personas.persona import persona_vars
-import time
-
+from behaving.personas.steps import *
+from behaving.web.steps import *
 from behaving.web.steps.basic import _retry
 
 APPLICATION_BACKDOOR = '/application_backdoor'
@@ -20,6 +15,29 @@ def i_wait_for_instance(context):
                 assert context.browser.is_element_present_by_css("[class='instance-status-light active']"), u'Instance failed to deploy'
                 break
             time.sleep(15)
+
+
+@step(u'I wait up to {timeout:d} seconds for instance with name "{name}" and provider "{provider}" to finish building')
+@step(u'I wait for instance with name "{name}" and provider "{provider}" to finish building')
+def wait_for_instance_to_finish_building(context, name, provider, timeout=60):
+    xpath_no_status = "//tr[contains(td[2], '{}') and contains(td[7], '{}')]".format(name, provider)
+    assert context.browser.is_element_present_by_xpath(xpath_no_status, wait_time=20), u'No such instance'
+    building_status = 'build'
+    xpath_with_status = "//tr[contains(td[2], '{}') and contains(td[7], '{}') and contains(td[3], '{}')]".format(name,
+                                                                                                                 provider,
+                                                                                                                 building_status)
+    assert context.browser.is_element_present_by_xpath(xpath_with_status), u'Instance is not building'
+    assert context.browser.is_element_not_present_by_xpath(xpath_with_status,
+                                                           wait_time=timeout), u'Instance has not finished building'
+
+
+@step(u'I should skip this scenario if I see an instance with "{name}" and provider "{provider}"')
+def skip_if_see_instance(context, name, provider):
+    xpath = "//tr[contains(td[2], '{}') and contains(td[7], '{}')]".format(name, provider)
+    if context.browser.is_element_present_by_xpath(xpath):
+        context.scenario.skip('An instance with name "{}" and provider "{}" already exists'.format(name, provider))
+
+
 
 @step(u'I type slowly "{value}" to "{index}" index of class "{klass}"')
 def i_type_to_index_of_class(context, klass, value, index):


### PR DESCRIPTION
… comment out already launched instances to prevent duplicates.

Solution: Wait until an instance has finished the 'build' phase before trying to launch the next one. This will prevent the 'Move to Project' dialog from popping up and breaking the tests. I also added a step to skip a scenario if an instance with the same name and provider already exists in the BDD project, making features simple and idempotent to run.