### PR TITLE
Problem: Installing a browser on a headless server is hard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ This repo provides tests for:
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 sudo apt-get update
-apt-get install google-chrome-unstable
+apt-get install google-chrome-unstable xvfb
 ```
 2. Download chromedriver
 ```bash
@@ -43,6 +43,12 @@ VERSION=$(curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 wget -O chromedriver.zip http://chromedriver.storage.googleapis.com/$VERSION/chromedriver_$PLATFORM.zip
 unzip chromedriver.zip
 mv chromedriver /usr/bin/
+```
+3. Run Xvfb ahead of tests
+```bash
+export DISPLAY=:1
+Xvfb $DISPLAY -ac -screen 0 1280x1024x8 &
+ps aux | grep Xvfb  # To verify it is running
 ```
 
 ### Set Up Environment Variables

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 behave==1.2.5             # via behaving
-behaving==1.5.4
+behaving==1.5.6
 enum34==1.1.6             # via parse-type
 parse-type==0.3.4         # via behave
 parse==1.6.6              # via behave, behaving, parse-type


### PR DESCRIPTION
Solution:
- Chrome 59 is fully headless with '--headless' argument
- Operation sanity can tap into this support by updating the browser
options ahead of test execution
- Include a debugger to determine when/how/where/why things went wrong.
Notes:
- Solution requires latest version of behaving