### PR TITLE
Problem: Chrome headless not working

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -27,9 +27,8 @@ def before_all(context):
         context.default_browser = 'chrome'
         options = Options()
         options.binary_location = '/usr/bin/google-chrome'
-        options.add_argument('headless')
-        options.add_argument('window-size=1920,1080')
-        options.add_argument('disable-gpu')
+        options.add_argument('--headless')
+        options.add_argument('--disable-gpu')
         context.browser_args = {
             'options': options,
         }
@@ -104,7 +103,8 @@ def after_step(context, step):
     https://pythonhosted.org/behave/tutorial.html#debug-on-error-in-case-of-step-failures
     """
     if step.status == "failed":
-        create_step_screenshot(context, step)
+        if context.screenshots_dir and hasattr(context, 'browser'):
+            create_step_screenshot(context, step)
         if BEHAVE_DEBUG_ON_ERROR:
             # -- ENTER DEBUGGER: Zoom in on failure location.
             import ipdb

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
 behaving
+chromedriver-installer

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,10 @@
 #
 behave==1.2.5             # via behaving
 behaving==1.5.6
+chromedriver-installer==0.0.6
 enum34==1.1.6             # via parse-type
-parse-type==0.3.4         # via behave
-parse==1.6.6              # via behave, behaving, parse-type
-selenium==2.53.5          # via splinter
-six==1.10.0               # via behave, parse-type
-splinter==0.7.3           # via behaving
+parse-type==0.4.2         # via behave
+parse==1.8.2              # via behave, behaving, parse-type
+selenium==3.6.0           # via splinter
+six==1.11.0               # via behave, parse-type
+splinter==0.7.6           # via behaving


### PR DESCRIPTION
Solution: Arguments were missing leading `--` characters.

Chrome was silently ignoring them.

For this to work `chromedriver` needs to be upgraded to at least
version 2.32.

Updated all requirements to latest versions while at it.

Update: Now installing latest version of `chromedriver` in the Python
virtual environment.